### PR TITLE
add rich text to table header

### DIFF
--- a/easyAppGui/Components/TableView.qml
+++ b/easyAppGui/Components/TableView.qml
@@ -130,6 +130,7 @@ Column {
                 const headerText = cells[cellIndex].headerText
                 qmlString +=
                         "EaComponents.TableViewLabel { \n" +
+                            `textFormat: Text.RichText \n` +
                             `text: '${headerText}' \n` +
                             `width: ${width} \n` +
                             `horizontalAlignment: ${horizontalAlignment} \n` +


### PR DESCRIPTION
Adding the option to use rich text (such as sub- and super-scripts) into the headers to tables. 